### PR TITLE
Combo graph: export to PNG (horizontal/vertical)

### DIFF
--- a/.claude/app-knowledge/combo-graph.md
+++ b/.claude/app-knowledge/combo-graph.md
@@ -10,7 +10,7 @@ A visual flow graph of a recorded combo, shown in a section **below** the play b
 |------|------|
 | `js/combo_graph.js` | `ComboGraph` class + singleton wiring (Rotate button, replay hooks) |
 | `css/combo_graph.css` | Node/arrow/zone-chip/`+`-connector styling, `.horizontal`/`.vertical`, `.cg-active` |
-| `index.html` | `<section class="combo-graph-section">` with `#combo-graph` + `#rotate-graph` button |
+| `index.html` | `<section class="combo-graph-section">` with `#combo-graph` + `#rotate-graph` + `#export-graph` buttons |
 
 Loaded **after** `simulator.js`/`main.js` (it reads the global `board` lazily, at click/hook time).
 
@@ -31,6 +31,7 @@ g.build(board.exportState())   // walk steps[] → graph events; build stepToNod
 g.setOrientation('vertical');  // or 'horizontal'; toggleOrientation() flips
 g.highlightStep(i);            // mark the node for original step index i (replay sync)
 g.clearHighlight();
+g.exportImage('horizontal');   // or 'vertical'; Promise<filename> — renders a PNG and downloads it
 ```
 
 `build()` keeps `stepToNode` (original step index → rendered-event index). Skipped steps (record markers, chat, shuffle) keep their index slot so live-replay highlighting stays aligned with `PlayLog.pointer`.
@@ -52,9 +53,21 @@ g.clearHighlight();
 
 **Card image:** `card.imageURL` → else `asset/card/<name>.jpeg` → `asset/back_card.png` on load error (mirrors `Card.drawHtml`). Zone chips are color-coded from `theme.css` `--bs-*` variables.
 
-## Auto-generate (no manual button)
+## Image export (PNG)
 
-The graph rebuilds itself via `window.comboGraphRefresh()` (= rebuild from the current `board.exportState()`); there is **no** "Generate" button, only **Rotate**. `comboGraphRefresh` is called from three load points in `simulator.js`:
+The **Export Image** button (`#export-graph`) saves the combo as a PNG. It opens a SweetAlert with two layout choices — **Horizontal** (`isConfirmed`) / **Vertical** (`isDenied`) — plus Cancel, then calls `g.exportImage(layout)`.
+
+`exportImage` does **not** screenshot the DOM. It draws from the structured `this.events` model onto an offscreen `<canvas>` with the Canvas 2D API (no third-party library), so the output is fully controllable and works for either orientation regardless of what's on screen. Pipeline:
+
+1. `_preloadExportImages` — collect unique card-image URLs, then `_loadExportImage` each with `crossOrigin='anonymous'` **and a cache-busting query** (`?_cgexp=<ts>`). The cache-buster forces a fresh CORS fetch (the art CDN sends an unconditional `access-control-allow-origin: *`), guaranteeing an **untainted** canvas so `toBlob()` can succeed even if the same art was cached earlier from a non-CORS request. Failed/timed-out (10 s) images fall back to the local back image, else a gray placeholder.
+2. `_drawExportCanvas` — measures/word-wraps card names (`_wrapText`, ≤2 lines + ellipsis), computes a uniform tile height, lays tiles + `+`/`→`/`↓` connectors in a row (horizontal) or column (vertical), and renders at 2× for crispness. The scale is **capped** so neither dimension exceeds 16384 px (long combos scale down instead of failing). Colors come from `EXPORT_PALETTE` (mirrors the default-theme `combo_graph.css` fallbacks). Includes a small `Combo Graph — N steps` header and a footer credit.
+3. `_downloadCanvas` — `canvas.toBlob()` → object-URL → click a temp `<a download>` → revoke. Filename: `combo-graph-<layout>-<N>steps.png`.
+
+All of this is still **read-only** w.r.t. board state (it only reads `this.events`, which `build()` populates from `exportState()`).
+
+## Auto-generate (no Generate button)
+
+The graph rebuilds itself via `window.comboGraphRefresh()` (= rebuild from the current `board.exportState()`); there is **no** "Generate" button (only **Rotate** and **Export Image**). `comboGraphRefresh` is called from three load points in `simulator.js`:
 
 1. **Stop Record** — the stop-record-button handler, after the `stopRecord` step.
 2. **`Board.importState()`** — after the playlog is restored (load a combo JSON → graph loads).

--- a/css/combo_graph.css
+++ b/css/combo_graph.css
@@ -30,6 +30,10 @@
     background: var(--bs-gray, #7d879c);
 }
 
+.combo-graph-toolbar button.cg-btn-export {
+    background: var(--bs-accent, #4e54c8);
+}
+
 .combo-graph-toolbar button:hover {
     filter: brightness(0.95);
 }

--- a/docs/combo-knowledge-pack/08-ui-rendering-and-menus.md
+++ b/docs/combo-knowledge-pack/08-ui-rendering-and-menus.md
@@ -36,7 +36,7 @@ body
     ├── #cardMenu.card-menu.menu-dialog                            ← per-card menu (opens on hover)
     └── #collectionMenu.collection-menu.menu-dialog
 section.combo-graph-section                                        ← below the board (see "Combo graph")
-    └── .combo-graph-toolbar (#rotate-graph) + #combo-graph.combo-graph.horizontal
+    └── .combo-graph-toolbar (#rotate-graph, #export-graph) + #combo-graph.combo-graph.horizontal
 ```
 
 Key facts:
@@ -127,6 +127,7 @@ jQuery UI **Touch Punch** (`js/jquery.ui.touch-punch.min.js`) enables drag-drop 
 - **Input:** the export's `playLogData.initItems`/`items` (→ a `uuid → {name, imageURL}` lookup) and `playLogData.steps[]` (→ the ordered flow). See [05-replay-and-playlog.md](05-replay-and-playlog.md).
 - **Each step → a node:** a position-changing `update` → card image + action verb (Draw / Summon / Send to GY / Banish / …) + a destination zone chip; `overlay` → a material node, with consecutive overlays joined by a `+`; fold/switch-only updates and `target`/`declare`/`reveal` → small badges; `update-phase` → a divider; record markers / `chat` / `shuffle` are skipped (their step index is preserved so replay highlighting stays aligned).
 - **Rotatable:** container class `.horizontal` ⇄ `.vertical` via the `#rotate-graph` button. There is **no** manual "Generate" button — it auto-builds.
+- **Export to PNG:** the `#export-graph` ("Export Image") button asks for a layout (Horizontal / Vertical via SweetAlert), then `ComboGraph.exportImage(layout)` draws the combo onto an offscreen `<canvas>` (Canvas 2D, no library — drawn from the structured event model, not a DOM screenshot) and downloads a PNG. Card art is (re)loaded `crossOrigin='anonymous'` with a cache-busting query so the canvas stays untainted (the art CDN sends `access-control-allow-origin: *`); the 2× render scale is capped so long combos never exceed the 16384 px canvas limit. Still read-only.
 - **Auto-build + live sync:** `window.comboGraphRefresh()` rebuilds from the current board on Stop Record, in `importState()`, and on initial load; during replay the engine calls guarded `comboGraphOnReplayStart` / `comboGraphOnStep` / `comboGraphOnReplayEnd` hooks to highlight the playing step. The highlight scrolls the active node into view **within the graph's own scroll box only** — it never scrolls the main page to the graph. Detail in [05-replay-and-playlog.md](05-replay-and-playlog.md).
 
 ---

--- a/index.html
+++ b/index.html
@@ -55,7 +55,7 @@
     <link rel="stylesheet" href="css/tournamentStyle.css?v=1.4" integrity="" />
     <link rel="stylesheet" href="css/app.css" integrity="" />
     <link rel="stylesheet" href="css/simulator.css?v=1.1.1" integrity="" />
-    <link rel="stylesheet" href="css/combo_graph.css?v=1.0" integrity="" />
+    <link rel="stylesheet" href="css/combo_graph.css?v=1.1" integrity="" />
     <script src="js/jquery.min.js?v=3.2.1"></script>
     <script src="js/jquery-ui.min.js?v=1.12.1"></script>
     <script src="js/jquery.ui.touch-punch.min.js?v=0.2.3"></script>
@@ -340,8 +340,9 @@
                 <div class="combo-graph-toolbar">
                     <h5>Combo Graph</h5>
                     <button type="button" id="rotate-graph" class="cg-btn-secondary">Rotate</button>
+                    <button type="button" id="export-graph" class="cg-btn-export">Export Image</button>
                 </div>
-                <p class="text-muted">The graph builds automatically when you Stop recording (or load a combo). Hit "Play" above to watch it highlight each step live, and "Rotate" to switch between horizontal and vertical.</p>
+                <p class="text-muted">The graph builds automatically when you Stop recording (or load a combo). Hit "Play" above to watch it highlight each step live, "Rotate" to switch between horizontal and vertical, and "Export Image" to save the combo as a PNG (choose a horizontal or vertical layout).</p>
                 <div id="combo-graph" class="combo-graph horizontal">
                     <div class="cg-empty">No combo recorded yet. Use Start Record &rarr; play your combo &rarr; Stop, then click "Generate Combo Graph".</div>
                 </div>
@@ -352,7 +353,7 @@
     <script src="js/simulator.js?v=1.1.3" integrity=""></script>
     <script src="js/main.js?v=1.1.1" integrity=""></script>
     <script src="js/Function.js?v=1.6" integrity=""></script>
-    <script src="js/combo_graph.js?v=1.2" integrity=""></script>
+    <script src="js/combo_graph.js?v=1.3" integrity=""></script>
 
     <!-- <script src="https://code.iconify.design/2/2.0.3/iconify.min.js" integrity=""></script> -->
     <!-- Main theme script-->

--- a/js/combo_graph.js
+++ b/js/combo_graph.js
@@ -321,6 +321,340 @@ class ComboGraph {
     clearHighlight() {
         this.nodeElements.forEach((node) => node.classList.remove('cg-active'));
     }
+
+    // ---- Image export ----------------------------------------------------
+    //
+    // Renders the combo to an offscreen <canvas> with the Canvas 2D API (no DOM
+    // capture, no third-party library) and downloads it as a PNG. We draw from
+    // the structured `this.events` model rather than scraping the rendered DOM,
+    // so the output is fully under our control and works for either orientation
+    // regardless of what is currently on screen.
+    //
+    // Card art lives on a cross-origin CDN, so every image is (re)loaded with
+    // crossOrigin='anonymous' AND a cache-busting query before being drawn. The
+    // cache-buster forces a fresh CORS request (the CDN sends an unconditional
+    // `access-control-allow-origin: *`), which guarantees an untainted canvas so
+    // toBlob()/toDataURL() can succeed even if the same art was previously cached
+    // from a non-CORS request elsewhere in the app.
+
+    static get EXPORT_PALETTE() {
+        // Mirrors the default-theme fallbacks in css/combo_graph.css so the export
+        // looks like the on-screen graph without depending on CSS-variable resolution.
+        return {
+            page: '#f3f5f9',     // .combo-graph background
+            tile: '#ffffff',
+            dark: '#373f50',
+            gray: '#7d879c',
+            primary: '#fe696a',
+            accent: '#4e54c8',
+            badgeBg: '#eef0f6',
+            phaseBg: '#fea569',
+            imgBg: '#d9dce5',
+            zones: {
+                hand: '#69b3fe', deck: '#373f50', exdeck: '#6f42c1',
+                summon: '#f34770', st: '#198754', fz: '#20c997',
+                graveyard: '#7d879c', banish: '#fd7e14', default: '#7d879c',
+            },
+        };
+    }
+
+    // Public: export the current combo as a PNG. `orientation` is 'horizontal'
+    // or 'vertical' (defaults to the graph's current orientation). Returns a
+    // Promise that resolves with the download filename, or rejects on failure.
+    exportImage(orientation) {
+        var layout = orientation === 'vertical' ? 'vertical'
+            : orientation === 'horizontal' ? 'horizontal'
+                : this.orientation;
+        var events = this.events || [];
+        if (!events.length) return Promise.reject(new Error('No combo to export.'));
+        var self = this;
+        return this._preloadExportImages(events)
+            .then(function (imgMap) { return self._drawExportCanvas(events, layout, imgMap); })
+            .then(function (canvas) { return self._downloadCanvas(canvas, layout, events.length); });
+    }
+
+    _preloadExportImages(events) {
+        var self = this;
+        var urls = [];
+        events.forEach(function (ev) {
+            if (ev.type === 'phase') return;
+            var u = self._cardImage(ev.card);
+            if (urls.indexOf(u) < 0) urls.push(u);
+        });
+        var bust = '_cgexp=' + (new Date()).getTime();   // fresh CORS fetch → no taint from a non-CORS cache hit
+        var map = {};
+        return Promise.all(urls.map(function (u) {
+            return self._loadExportImage(u, bust).then(function (img) { map[u] = img; });
+        })).then(function () { return map; });
+    }
+
+    // Load one image CORS-enabled (cache-busted); on failure fall back to the
+    // local back image; resolve null if even that fails or it times out. Never rejects.
+    _loadExportImage(url, bust) {
+        var back = this.options.backImage;
+        function load(src, allowFallback) {
+            return new Promise(function (resolve) {
+                var settled = false;
+                var img = new Image();
+                img.crossOrigin = 'anonymous';
+                var timer = setTimeout(function () {
+                    if (settled) return; settled = true; resolve(null);
+                }, 10000);
+                img.onload = function () {
+                    if (settled) return; settled = true; clearTimeout(timer); resolve(img);
+                };
+                img.onerror = function () {
+                    if (settled) return; settled = true; clearTimeout(timer);
+                    if (allowFallback) { load(back, false).then(resolve); }
+                    else { resolve(null); }
+                };
+                var sep = src.indexOf('?') < 0 ? '?' : '&';
+                img.src = bust ? src + sep + bust : src;
+            });
+        }
+        return load(url, url !== back);
+    }
+
+    // Word-wrap `text` to at most `maxLines` lines no wider than `maxWidth`,
+    // adding an ellipsis when content (or a single long word) overflows.
+    _wrapText(ctx, text, maxWidth, maxLines) {
+        text = String(text == null ? '' : text);
+        var words = text.split(/\s+/).filter(Boolean);
+        if (!words.length) return [''];
+        var lines = [];
+        var cur = '';
+        for (var i = 0; i < words.length; i++) {
+            var test = cur ? cur + ' ' + words[i] : words[i];
+            if (ctx.measureText(test).width <= maxWidth || !cur) {
+                cur = test;
+            } else {
+                lines.push(cur);
+                cur = words[i];
+                if (lines.length === maxLines) { cur = ''; break; }
+            }
+        }
+        if (cur && lines.length < maxLines) lines.push(cur);
+        if (lines.length === maxLines) {
+            var consumed = lines.join(' ').split(/\s+/).filter(Boolean).length;
+            if (consumed < words.length) {
+                var last = lines[maxLines - 1];
+                while (last && ctx.measureText(last + '…').width > maxWidth) last = last.slice(0, -1);
+                lines[maxLines - 1] = last + '…';
+            }
+        }
+        for (var j = 0; j < lines.length; j++) {
+            if (ctx.measureText(lines[j]).width > maxWidth) {
+                var s = lines[j];
+                while (s && ctx.measureText(s + '…').width > maxWidth) s = s.slice(0, -1);
+                lines[j] = s + '…';
+            }
+        }
+        return lines.length ? lines : [''];
+    }
+
+    _drawExportCanvas(events, layout, imgMap) {
+        var self = this;
+        var P = ComboGraph.EXPORT_PALETTE;
+        var FONT = '"Segoe UI", Roboto, Helvetica, Arial, sans-serif';
+        var canvas = document.createElement('canvas');
+        var ctx = canvas.getContext('2d');
+
+        // Layout constants (logical px, before the DPI scale below).
+        var TILE_W = 152, IMG_W = 84, IMG_H = 120;
+        var CONN = 32, OUTER = 24, HEADER = 34, FOOTER = 22;
+        var PAD_TOP = 16, PAD_BOT = 14, GAP = 6, NAME_LH = 14;
+        var ACTION_H = 16, FROMTO_H = 13, CHIP_H = 22;
+
+        // Measure + wrap card names (<=2 lines) and find the tallest stack.
+        ctx.font = '600 11px ' + FONT;
+        var maxNameLines = 1;
+        events.forEach(function (ev) {
+            if (ev.type === 'phase') { ev._lines = [String(ev.phase || 'phase').toUpperCase()]; return; }
+            var name = (ev.card && ev.card.name) || 'Unknown';
+            ev._lines = self._wrapText(ctx, name, TILE_W - 20, 2);
+            if (ev._lines.length > maxNameLines) maxNameLines = ev._lines.length;
+        });
+
+        // Uniform tile height = the tallest content stack (a 'move' tile).
+        var ROW_H = PAD_TOP + IMG_H + GAP + (maxNameLines * NAME_LH) + GAP
+            + ACTION_H + 2 + FROMTO_H + 4 + CHIP_H + PAD_BOT;
+
+        var n = events.length;
+        var W, H;
+        if (layout === 'vertical') {
+            W = OUTER * 2 + TILE_W;
+            H = OUTER * 2 + HEADER + (n * ROW_H) + ((n - 1) * CONN) + FOOTER;
+        } else {
+            W = OUTER * 2 + (n * TILE_W) + ((n - 1) * CONN);
+            H = OUTER * 2 + HEADER + ROW_H + FOOTER;
+        }
+        var contentX = OUTER;
+        var contentY = OUTER + HEADER;
+
+        // Render at 2x for crisp output, but cap so we never exceed the browser
+        // canvas dimension limit on very long combos.
+        var MAX_PX = 16384;
+        var scale = Math.min(2, MAX_PX / W, MAX_PX / H);
+        if (!isFinite(scale) || scale <= 0) scale = 1;
+        canvas.width = Math.ceil(W * scale);
+        canvas.height = Math.ceil(H * scale);
+        ctx.scale(scale, scale);
+
+        // ---- drawing helpers (closures over ctx) ----
+        function roundRect(x, y, w, h, r) {
+            r = Math.min(r, w / 2, h / 2);
+            ctx.beginPath();
+            ctx.moveTo(x + r, y);
+            ctx.arcTo(x + w, y, x + w, y + h, r);
+            ctx.arcTo(x + w, y + h, x, y + h, r);
+            ctx.arcTo(x, y + h, x, y, r);
+            ctx.arcTo(x, y, x + w, y, r);
+            ctx.closePath();
+        }
+        function truncate(text, maxW) {
+            text = String(text == null ? '' : text);
+            if (ctx.measureText(text).width <= maxW) return text;
+            while (text && ctx.measureText(text + '…').width > maxW) text = text.slice(0, -1);
+            return text + '…';
+        }
+        function pill(text, cx, cy, bg, fg, maxW) {
+            var t = truncate(text, maxW - 16);
+            var w = ctx.measureText(t).width + 16;
+            roundRect(cx - w / 2, cy - CHIP_H / 2, w, CHIP_H, CHIP_H / 2);
+            ctx.fillStyle = bg; ctx.fill();
+            ctx.fillStyle = fg; ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+            ctx.fillText(t, cx, cy + 0.5);
+        }
+        function cardImage(img, dx, dy) {
+            ctx.save();
+            roundRect(dx, dy, IMG_W, IMG_H, 4);
+            ctx.clip();
+            if (img && img.naturalWidth) {
+                var s = Math.max(IMG_W / img.naturalWidth, IMG_H / img.naturalHeight); // object-fit: cover
+                var sw = IMG_W / s, sh = IMG_H / s;
+                ctx.drawImage(img, (img.naturalWidth - sw) / 2, (img.naturalHeight - sh) / 2, sw, sh, dx, dy, IMG_W, IMG_H);
+            } else {
+                ctx.fillStyle = P.imgBg; ctx.fillRect(dx, dy, IMG_W, IMG_H);
+            }
+            ctx.restore();
+            roundRect(dx, dy, IMG_W, IMG_H, 4);
+            ctx.lineWidth = 1; ctx.strokeStyle = 'rgba(0,0,0,0.10)'; ctx.stroke();
+        }
+        function stepNum(num, x, y) {
+            var r = 11, cx = x + r, cy = y + r;
+            ctx.beginPath(); ctx.arc(cx, cy, r, 0, Math.PI * 2);
+            ctx.fillStyle = P.dark; ctx.fill();
+            ctx.fillStyle = '#fff'; ctx.font = '700 11px ' + FONT;
+            ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+            ctx.fillText(String(num), cx, cy + 0.5);
+        }
+        function drawTile(ev, i, x, y) {
+            var center = x + TILE_W / 2;
+            if (ev.type === 'phase') {
+                pill((ev._lines && ev._lines[0]) || 'PHASE', center, y + ROW_H / 2, P.phaseBg, '#fff', TILE_W - 8);
+                return;
+            }
+            ctx.save();
+            ctx.shadowColor = 'rgba(0,0,0,0.10)';
+            ctx.shadowBlur = 6;
+            ctx.shadowOffsetY = 2;
+            roundRect(x, y, TILE_W, ROW_H, 8);
+            ctx.fillStyle = P.tile; ctx.fill();
+            ctx.restore();
+
+            stepNum(i + 1, x + 4, y + 4);
+            cardImage(imgMap[self._cardImage(ev.card)], center - IMG_W / 2, y + PAD_TOP);
+
+            ctx.fillStyle = P.dark; ctx.font = '600 11px ' + FONT;
+            ctx.textAlign = 'center'; ctx.textBaseline = 'top';
+            var ny = y + PAD_TOP + IMG_H + GAP;
+            (ev._lines || []).forEach(function (ln) { ctx.fillText(ln, center, ny); ny += NAME_LH; });
+            var below = ny + GAP;
+
+            if (ev.type === 'move') {
+                ctx.fillStyle = P.dark; ctx.font = '700 12px ' + FONT;
+                ctx.fillText(truncate('→ ' + ev.actionLabel, TILE_W - 12), center, below);
+                ctx.fillStyle = P.gray; ctx.font = '400 10px ' + FONT;
+                ctx.fillText(truncate(ev.fromZone + ' → ' + ev.toZone, TILE_W - 12), center, below + ACTION_H + 2);
+                var chipColor = P.zones[ev.to] || P.zones.default;
+                pill(ev.toZone, center, below + ACTION_H + 2 + FROMTO_H + 4 + CHIP_H / 2, chipColor, '#fff', TILE_W - 12);
+            } else if (ev.type === 'overlay') {
+                pill(ev.actionLabel || 'Xyz Material', center, below + CHIP_H / 2, P.accent, '#fff', TILE_W - 12);
+            } else if (ev.type === 'badge') {
+                pill(ev.badge || '', center, below + CHIP_H / 2, P.badgeBg, P.dark, TILE_W - 12);
+            }
+        }
+
+        // ---- background + header + footer ----
+        ctx.fillStyle = P.page; ctx.fillRect(0, 0, W, H);
+        ctx.fillStyle = P.dark; ctx.font = '700 16px ' + FONT;
+        ctx.textAlign = 'left'; ctx.textBaseline = 'middle';
+        ctx.fillText('Combo Graph — ' + n + ' step' + (n === 1 ? '' : 's'), OUTER, OUTER + HEADER / 2);
+        ctx.fillStyle = P.gray; ctx.font = '400 11px ' + FONT;
+        ctx.fillText('YuGi-Oh! Simulator', OUTER, H - OUTER - FOOTER / 2);
+
+        // ---- tiles + connectors ----
+        var pos = layout === 'vertical' ? contentY : contentX;
+        events.forEach(function (ev, i) {
+            if (layout === 'vertical') drawTile(ev, i, contentX, pos);
+            else drawTile(ev, i, pos, contentY);
+            pos += (layout === 'vertical' ? ROW_H : TILE_W);
+            if (i < n - 1) {
+                var combine = ev.type === 'overlay' && events[i + 1].type === 'overlay';
+                ctx.fillStyle = combine ? P.accent : P.gray;
+                ctx.font = (combine ? '700 22px ' : '400 20px ') + FONT;
+                ctx.textAlign = 'center'; ctx.textBaseline = 'middle';
+                if (layout === 'vertical') ctx.fillText(combine ? '+' : '↓', contentX + TILE_W / 2, pos + CONN / 2);
+                else ctx.fillText(combine ? '+' : '→', pos + CONN / 2, contentY + ROW_H / 2);
+                pos += CONN;
+            }
+        });
+        return Promise.resolve(canvas);
+    }
+
+    _downloadCanvas(canvas, layout, stepCount) {
+        return new Promise(function (resolve, reject) {
+            var filename = 'combo-graph-' + layout + '-' + stepCount + 'steps.png';
+            var settled = false;
+            var triggerDownload = function (href, revoke) {
+                if (settled) return; settled = true;
+                var a = document.createElement('a');
+                a.href = href; a.download = filename;
+                document.body.appendChild(a);
+                a.click();
+                document.body.removeChild(a);
+                if (revoke) setTimeout(function () { URL.revokeObjectURL(href); }, 1500);
+                resolve(filename);
+            };
+            // Synchronous fallback. toDataURL either returns a string or throws
+            // synchronously (e.g. a tainted canvas), so it can never hang.
+            var fallbackDataUrl = function () {
+                if (settled) return;
+                try { triggerDownload(canvas.toDataURL('image/png'), false); }
+                catch (e) { if (!settled) { settled = true; reject(e); } }
+            };
+            // toBlob is async; if a non-spec browser/OOM ever fails to invoke the
+            // callback, the "Generating…" modal would hang forever — so guard it
+            // with a timeout that falls back to the (synchronous) data-URL path.
+            var timer = setTimeout(fallbackDataUrl, 12000);
+            try {
+                if (canvas.toBlob) {
+                    canvas.toBlob(function (blob) {
+                        clearTimeout(timer);
+                        if (settled) return;
+                        if (!blob) { fallbackDataUrl(); return; }   // encode failed → try data URL
+                        triggerDownload(URL.createObjectURL(blob), true);
+                    }, 'image/png');
+                } else {
+                    clearTimeout(timer);
+                    fallbackDataUrl();
+                }
+            } catch (e) {
+                clearTimeout(timer);
+                if (!settled) { settled = true; reject(e); }
+            }
+        });
+    }
 }
 
 // ---- Singleton wiring ----------------------------------------------------
@@ -348,6 +682,60 @@ class ComboGraph {
         g.build(board.exportState()).render();
     }
 
+    // Ask for a layout (Horizontal / Vertical), then render + download the PNG.
+    function exportGraph() {
+        var g = getGraph();
+        var hasSwal = typeof Swal !== 'undefined';
+        if (!g || !g.events || !g.events.length) {
+            if (hasSwal) {
+                Swal.fire({
+                    icon: 'info', title: 'Nothing to export',
+                    text: 'Record or load a combo first.',
+                    timer: 1800, showConfirmButton: false,
+                });
+            }
+            return;
+        }
+        var run = function (orientation) {
+            if (hasSwal) {
+                Swal.fire({
+                    title: 'Generating image…',
+                    allowOutsideClick: false,
+                    didOpen: function () { Swal.showLoading(); },
+                });
+            }
+            g.exportImage(orientation).then(function (filename) {
+                if (hasSwal) {
+                    Swal.fire({
+                        toast: true, position: 'top-end', icon: 'success',
+                        title: 'Saved ' + filename, showConfirmButton: false, timer: 2200,
+                    });
+                }
+            }).catch(function (err) {
+                if (hasSwal) {
+                    Swal.fire({
+                        icon: 'error', title: 'Export failed',
+                        text: (err && err.message) || 'Could not generate the image.',
+                    });
+                }
+            });
+        };
+        if (!hasSwal) { run(g.orientation); return; }
+        Swal.fire({
+            title: 'Export Combo Graph',
+            text: 'Choose a layout for the exported image.',
+            icon: 'question',
+            showDenyButton: true,
+            showCancelButton: true,
+            confirmButtonText: 'Horizontal',
+            denyButtonText: 'Vertical',
+            cancelButtonText: 'Cancel',
+        }).then(function (result) {
+            if (result.isConfirmed) run('horizontal');
+            else if (result.isDenied) run('vertical');
+        });
+    }
+
     document.addEventListener('DOMContentLoaded', function () {
         var rotateBtn = document.getElementById('rotate-graph');
         if (rotateBtn) {
@@ -355,6 +743,10 @@ class ComboGraph {
                 var g = getGraph();
                 if (g) g.toggleOrientation();
             });
+        }
+        var exportBtn = document.getElementById('export-graph');
+        if (exportBtn) {
+            exportBtn.addEventListener('click', exportGraph);
         }
     });
 


### PR DESCRIPTION
## What

Adds an **Export Image** button to the Combo Graph toolbar. Clicking it opens a SweetAlert with **Horizontal** / **Vertical** / Cancel, then renders the recorded combo to a downloadable PNG via `ComboGraph.exportImage(layout)`.

## Why

Players want to save and share a recorded combo as an image. The graph already has a structured event model and a rotatable layout, so this exposes both as a static export.

## How

**Vanilla Canvas 2D — no third-party library, no DOM screenshot.** It draws from the graph's `this.events` model directly onto an offscreen `<canvas>`, so the output is fully controllable and works for either orientation regardless of what's on screen.

The main hurdle was **CORS canvas tainting** — card art is cross-origin (`ygovietnamcdn.azureedge.net`). The CDN sends an unconditional `access-control-allow-origin: *`, so images are loaded `crossOrigin='anonymous'` with a cache-busting query (to avoid re-tainting from a previously cached non-CORS response). This keeps the canvas untainted so `toBlob()`/`toDataURL()` succeed.

Notable details:
- `_drawExportCanvas`: word-wraps card names (≤2 lines + ellipsis), uniform tile height, `+`/`→`/`↓` connectors, 2× render scale **capped** so neither dimension exceeds the 16384px canvas limit (long combos scale down instead of failing). Colors mirror the default-theme `combo_graph.css` fallbacks.
- `_downloadCanvas`: `toBlob` path with a 12s timeout fallback to the synchronous `toDataURL` path, so a non-spec/OOM `toBlob` that never fires its callback can't hang the (non-dismissable) "Generating…" modal.
- Stays **read-only** w.r.t. board state and export/import.

## Files
- `js/combo_graph.js` — `exportImage`, `_loadExportImage`, `_drawExportCanvas`, `_wrapText`, `_downloadCanvas`, button wiring
- `index.html` — `#export-graph` button + help text; cache-bust bumps (`combo_graph.js?v=1.3`, `combo_graph.css?v=1.1`)
- `css/combo_graph.css` — accent-styled export button
- Docs synced in both homes: `.claude/app-knowledge/combo-graph.md` and `docs/combo-knowledge-pack/08-ui-rendering-and-menus.md`

## Testing

Verified live against a 34-step combo in the local preview:
- 9/9 CDN images loaded **CORS-clean**; both orientations produced **untainted, valid PNGs** (`toDataURL` succeeds).
- Long vertical combo hit the 16384px cap and scaled down gracefully instead of failing.
- Pixel inspection confirmed correct theme rendering (page bg, white tiles, zone-chip colors, text); no console errors.
- `_downloadCanvas`: both the `toBlob` path and the forced `toDataURL` fallback resolve with the correct filename, exactly one download each (no double-fire).

An adversarial multi-agent review of the diff surfaced one robustness gap (the `toBlob` hang), which is fixed above; three other findings were verified as non-issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)